### PR TITLE
Upgrade `babel-plugin-styled-components` to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "awesome-typescript-loader": "^3.1.3",
     "babel-cli": "^6.23.0",
     "babel-loader": "^7.1.2",
-    "babel-plugin-styled-components": "^1.2.1",
+    "babel-plugin-styled-components": "^1.3.0",
     "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.1.10",
     "babel-preset-react": "^6.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -463,12 +463,12 @@ babel-plugin-check-es2015-constants@^6.22.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-styled-components@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.2.1.tgz#e1593f2a6a0327e2d156695306e60c4dd175866d"
+babel-plugin-styled-components@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.3.0.tgz#9e4d9f718b2975dadbfab0bc1c6793d93c751404"
   dependencies:
     babel-types "^6.26.0"
-    stylis "^3.2.1"
+    stylis "3.x"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -4273,6 +4273,10 @@ styled-components@^2.1.2:
     prop-types "^15.5.4"
     stylis "^3.2.1"
     supports-color "^3.2.3"
+
+stylis@3.x:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.4.0.tgz#55c6530ebceeca5976d54fb4adc67578afee828d"
 
 stylis@^3.2.1:
   version "3.2.13"


### PR DESCRIPTION
This is to show classNames of styled-components when debugging.

<!--- 
Thanks for the contribution. We appreciate it.
Be sure to checkout our guideline.
-->
## Related Issues
#169

## Checklist
- [ ] Tested successfully.
- [ ] Titles of commit message and PR are in English.
- [ ] PR number at the title will be removed when `squash and merge`.
- [ ] [Guideline](https://github.com/tymsai/marmoym-dev-support/blob/dev/CONTRIBUTING.md#commit-messages) is followed. 